### PR TITLE
Fix popover props issue; add test for issue; bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "he-react-ui",
-  "version": "0.0.80",
+  "version": "0.0.82",
   "description": "Common UI elements for HealthEngine",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Popover/index.js
+++ b/src/components/Popover/index.js
@@ -60,7 +60,7 @@ export default class Popover extends React.Component {
         </Tippy>
 
         {!this.fullyMounted && (
-          <span ref={this.notifyMount} style={style.hidden} />
+          <span ref={this.notifyMount} className={style.hidden} />
         )}
       </React.Fragment>
     );

--- a/src/components/Popover/tests/Popover.test.js
+++ b/src/components/Popover/tests/Popover.test.js
@@ -1,0 +1,9 @@
+import createTestContext from 'react-cosmos-test/enzyme';
+import fixtures from '../Popover.fixtures';
+
+const { mount, getWrapper } = createTestContext({ fixture: fixtures[0] });
+beforeEach(mount);
+
+test(`<Popover /> rendered correctly with base fixture`, () => {
+  expect(getWrapper()).toMatchSnapshot();
+});

--- a/src/components/Popover/tests/__snapshots__/Popover.test.js.snap
+++ b/src/components/Popover/tests/__snapshots__/Popover.test.js.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Popover /> rendered correctly with base fixture 1`] = `
+<Popover
+  content="WOW!"
+>
+  <Tooltip
+    animateFill={true}
+    animation="shift"
+    arrow={false}
+    arrowSize="regular"
+    className=""
+    delay={100}
+    disabled={false}
+    distance={10}
+    duration={375}
+    followCursor={false}
+    hideDelay={300}
+    hideDuration={375}
+    hideOnClick={true}
+    html={
+      <PopoverDisplay
+        className={undefined}
+        light={undefined}
+        tooltip={undefined}
+      >
+        WOW!
+      </PopoverDisplay>
+    }
+    inertia={false}
+    interactive={true}
+    interactiveBorder={16}
+    multiple={false}
+    offset={0}
+    onHidden={[Function]}
+    onHide={[Function]}
+    onRequestClose={[Function]}
+    onShow={[Function]}
+    onShown={[Function]}
+    popperOptions={Object {}}
+    position="bottom-start"
+    size="regular"
+    sticky={false}
+    stickyDuration={200}
+    style={Object {}}
+    theme="dark"
+    touchHold={false}
+    trigger="mouseenter"
+    unmountHTMLWhenHide={false}
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "display": "inline",
+        }
+      }
+    >
+      <Icon
+        name="Help"
+        style={
+          Object {
+            "cursor": "pointer",
+          }
+        }
+      >
+        <Help
+          className="icon"
+          style={
+            Object {
+              "cursor": "pointer",
+            }
+          }
+        >
+          <svg
+            className="icon"
+            style={
+              Object {
+                "cursor": "pointer",
+              }
+            }
+            version="1.1"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              transform="translate(1.000000, 1.000000)"
+            >
+              <path
+                d="M 11,-1 C 4.3844276,-1 -1,4.3844276 -1,11 -1,17.615572 4.3844276,23 11,23 17.615572,23 23,17.615572 23,11 23,4.3844276 17.615572,-1 11,-1 Z m 0,2 C 16.534692,1 21,5.4653079 21,11 21,16.534692 16.534692,21 11,21 5.4653079,21 1,16.534692 1,11 1,5.4653079 5.4653079,1 11,1 Z"
+              />
+              <path
+                d="M 11,5 C 9.3073959,5 7.906242,6.1140807 7.2910156,7.5195312 A 1.0009847,1.0009847 0 1 0 9.125,8.3222656 C 9.4097736,7.6717161 10.304604,7 11,7 c 1.032659,0 2,0.9673414 2,2 0,1.032659 -0.967341,2 -2,2 a 1.0001,1.0001 0 0 0 -1,1 v 2 a 1.0001,1.0001 0 1 0 2,0 V 12.794922 C 13.700153,12.334832 15,10.832206 15,9 15,6.8146586 13.185341,5 11,5 Z"
+              />
+              <path
+                d="m 12,17 a 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 1,1 0 0 1 1,1 z"
+              />
+            </g>
+          </svg>
+        </Help>
+      </Icon>
+    </div>
+  </Tooltip>
+  <span
+    className="hidden"
+  />
+</Popover>
+`;

--- a/src/components/__snapshots__/allComponents.test.js.snap
+++ b/src/components/__snapshots__/allComponents.test.js.snap
@@ -8248,7 +8248,7 @@ exports[`Cosmos fixtures: Popover:base 1`] = `
     </div>
   </div>
   <span
-    style="hidden"
+    className="hidden"
   />
 </div>
 `;
@@ -8313,7 +8313,7 @@ exports[`Cosmos fixtures: Popover:className 1`] = `
     </div>
   </div>
   <span
-    style="hidden"
+    className="hidden"
   />
 </div>
 `;
@@ -8437,7 +8437,7 @@ exports[`Cosmos fixtures: Popover:complexContent 1`] = `
     </div>
   </div>
   <span
-    style="hidden"
+    className="hidden"
   />
 </div>
 `;
@@ -8502,7 +8502,7 @@ exports[`Cosmos fixtures: Popover:light 1`] = `
     </div>
   </div>
   <span
-    style="hidden"
+    className="hidden"
   />
 </div>
 `;
@@ -8567,7 +8567,7 @@ exports[`Cosmos fixtures: Popover:preferRight 1`] = `
     </div>
   </div>
   <span
-    style="hidden"
+    className="hidden"
   />
 </div>
 `;
@@ -8632,7 +8632,7 @@ exports[`Cosmos fixtures: Popover:tooltip 1`] = `
     </div>
   </div>
   <span
-    style="hidden"
+    className="hidden"
   />
 </div>
 `;
@@ -8697,7 +8697,7 @@ exports[`Cosmos fixtures: Popover:triggerOnClick 1`] = `
     </div>
   </div>
   <span
-    style="hidden"
+    className="hidden"
   />
 </div>
 `;


### PR DESCRIPTION
We were passing a `style` prop instead of a `className` prop. Surprisingly, this triggered an error in the browser, but not in the automatic fixture test. Adding a manual fixture test caught this. I will investigate why these behave differently.