### PR TITLE
Ensure outer wrapper for PrimaryNav is never offset from the corner

### DIFF
--- a/src/components/Form/DatePickers/SingleDatePicker/fixtures/focusedWithValue.fixture.js
+++ b/src/components/Form/DatePickers/SingleDatePicker/fixtures/focusedWithValue.fixture.js
@@ -9,6 +9,6 @@ export default {
   props: {
     id: 'demo',
     name: 'demo',
-    value: moment(),
+    value: moment('2018-06-19'),
   },
 };

--- a/src/components/Navigation/PrimaryNavigation/PrimaryNavigation.scss
+++ b/src/components/Navigation/PrimaryNavigation/PrimaryNavigation.scss
@@ -75,6 +75,8 @@ $slider-width: 264px;
   height: 100%;
   width: 100%;
   position: absolute;
+  top: 0;
+  left: 0;
 }
 
 .spacer {

--- a/src/components/__snapshots__/allComponents.test.js.snap
+++ b/src/components/__snapshots__/allComponents.test.js.snap
@@ -11235,7 +11235,7 @@ exports[`Cosmos fixtures: SingleDatePicker:focusedWithValue 1`] = `
               readOnly={false}
               required={false}
               type="text"
-              value="18/06/2018"
+              value="19/06/2018"
             />
             <p
               className="DateInput_screenReaderMessage DateInput_screenReaderMessage_1"


### PR DESCRIPTION
Fixes an issue where the contents of a PrimaryNavigation could be offset from their parent.

Example of bug:

![image](https://user-images.githubusercontent.com/185582/41571287-0fde5884-73a5-11e8-91ed-750e672d75b1.png)
