### PR TITLE
Don't fix lint by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "coverage": "NODE_ENV=test jest --env=jsdom --coverage",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
     "test:watch": "yarn test -- --watch",
-    "lint": "eslint . --fix --env jest",
+    "lint": "eslint . --env jest",
+    "lint-fix": "eslint . --fix --env jest",
     "cosmos": "cosmos"
   },
   "keywords": [


### PR DESCRIPTION
This means that we don't actually pick up lint errors properly in travis