### PR TITLE
Fix pernicious ref bug when rendering singleSelects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "he-react-ui",
-  "version": "0.1.5",
+  "version": "0.1.51",
   "description": "Common UI elements for HealthEngine",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Form/SingleSelect/SingleSelect.js
+++ b/src/components/Form/SingleSelect/SingleSelect.js
@@ -128,6 +128,7 @@ class SingleSelect extends React.Component<Props, *> {
             })}
           >
             <Select
+              joinValues
               options={options}
               className={classnames(style.select, {
                 [style.expanded]: expanded,


### PR DESCRIPTION
adds the `joinValues` prop to the inner react-select used in SingleSelect. This fixes issues where react-select converts passed values into string-refs, which sometimes break.