### PR TITLE
Allow <Button /> to open links in a new window

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "lines": 85.81,
         "statements": 85.81,
         "functions": 75.61,
-        "branches": 81.98
+        "branches": 82.07
       }
     },
     "coverageReporters": [

--- a/package.json
+++ b/package.json
@@ -107,10 +107,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 85.81,
-        "statements": 85.81,
+        "lines": 85.83,
+        "statements": 85.83,
         "functions": 75.61,
-        "branches": 82.07
+        "branches": 82.16
       }
     },
     "coverageReporters": [

--- a/src/components/Form/Button/Button.js
+++ b/src/components/Form/Button/Button.js
@@ -20,8 +20,17 @@ function InnerButton(props: {
   children: any,
   className: string,
   onClick: ?Function,
+  newWindow?: boolean,
 }) {
-  const { to, withRouter, submit, children, className, onClick } = props;
+  const {
+    to,
+    withRouter,
+    submit,
+    children,
+    className,
+    onClick,
+    newWindow,
+  } = props;
   if (!to) {
     return (
       <button
@@ -34,12 +43,14 @@ function InnerButton(props: {
     );
   }
 
+  const targetProp = newWindow ? { target: '_blank' } : {};
+
   return withRouter ? (
-    <Link to={to} className={className}>
+    <Link to={to} className={className} {...targetProp}>
       {children}
     </Link>
   ) : (
-    <a href={to} className={className}>
+    <a href={to} className={className} {...targetProp}>
       {children}
     </a>
   );
@@ -65,6 +76,7 @@ type Props = {
   className?: string,
   to?: string,
   withRouter: boolean,
+  newWindow: boolean,
 };
 
 class Button extends React.Component<Props> {
@@ -78,6 +90,7 @@ class Button extends React.Component<Props> {
     squared: false,
     onClick: () => null,
     withRouter: false,
+    newWindow: false,
   };
 
   handleClick = (event: SyntheticEvent<*>) => {
@@ -106,6 +119,7 @@ class Button extends React.Component<Props> {
       done,
       to,
       withRouter,
+      newWindow,
     } = this.props;
 
     const buttonClasses = classnames(
@@ -149,6 +163,7 @@ class Button extends React.Component<Props> {
           to={to}
           withRouter={withRouter}
           onClick={this.handleClick}
+          newWindow={newWindow}
         >
           {statusIcon || (
             <Fragment>

--- a/src/components/Form/Button/fixtures/toUrl.fixture.js
+++ b/src/components/Form/Button/fixtures/toUrl.fixture.js
@@ -22,4 +22,14 @@ export default [
     children: 'I am a <Link /> tag',
     simulateSubmission: true,
   },
+
+  {
+    name: 'toNewWindowUrl',
+    component: Button,
+    props: {
+      to: '#this-works!',
+      newWindow: true,
+    },
+    children: 'I am an <a  target="_blank" /> tag',
+  },
 ];

--- a/src/components/Form/Button/tests/__snapshots__/Blue.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Blue.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with blue fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with blue fixture 1`] = `
   >
     <InnerButton
       className="button blue"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Default.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Default.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with default fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with default fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Green.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Green.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with green fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with green fixture 1`] = `
   >
     <InnerButton
       className="button green"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Icon-legacy.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Icon-legacy.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with legacy icon fixture 1`] = `
   icon="Sync"
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with legacy icon fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Keyline.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Keyline.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   icon=""
   keyline={true}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   >
     <InnerButton
       className="button teal keyline"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Link.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Link.test.js.snap
@@ -7,6 +7,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   icon=""
   keyline={false}
   link={true}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -17,6 +18,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   >
     <InnerButton
       className="button teal link"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Red.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Red.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with red fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with red fixture 1`] = `
   >
     <InnerButton
       className="button red"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/White.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/White.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with white fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with white fixture 1`] = `
   >
     <InnerButton
       className="button white"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/disabled.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/disabled.test.js.snap
@@ -7,6 +7,7 @@ exports[`<Button /> rendered correctly with disabled fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -17,6 +18,7 @@ exports[`<Button /> rendered correctly with disabled fixture 1`] = `
   >
     <InnerButton
       className="button teal disabled"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/done.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/done.test.js.snap
@@ -13,6 +13,7 @@ exports[`<Button /> rendered correctly with done fixture 1`] = `
   }
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -23,6 +24,7 @@ exports[`<Button /> rendered correctly with done fixture 1`] = `
   >
     <InnerButton
       className="button done"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/iconLeft-Long-Title.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/iconLeft-Long-Title.test.js.snap
@@ -13,6 +13,7 @@ exports[`<Button /> rendered correctly with long-title fixture 1`] = `
   }
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -24,6 +25,7 @@ exports[`<Button /> rendered correctly with long-title fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/iconLeft.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/iconLeft.test.js.snap
@@ -13,6 +13,7 @@ exports[`<Button /> rendered correctly with iconLeft fixture 1`] = `
   }
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -24,6 +25,7 @@ exports[`<Button /> rendered correctly with iconLeft fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/iconRight.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/iconRight.test.js.snap
@@ -13,6 +13,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   }
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -24,6 +25,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/large.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/large.test.js.snap
@@ -9,6 +9,7 @@ exports[`<Button /> rendered correctly with large fixture 1`] = `
   keyline={false}
   large={true}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -20,6 +21,7 @@ exports[`<Button /> rendered correctly with large fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/small.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/small.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with small fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   small={true}
   squared={false}
@@ -20,6 +21,7 @@ exports[`<Button /> rendered correctly with small fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/squared.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/squared.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with squared fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={true}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with squared fixture 1`] = `
   >
     <InnerButton
       className="button teal squared"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/style.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/style.test.js.snap
@@ -7,6 +7,7 @@ exports[`<Button /> rendered correctly with style fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   style={
@@ -33,6 +34,7 @@ exports[`<Button /> rendered correctly with style fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/submitting.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/submitting.test.js.snap
@@ -12,6 +12,7 @@ exports[`<Button /> rendered correctly with submitting fixture 1`] = `
   }
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -23,6 +24,7 @@ exports[`<Button /> rendered correctly with submitting fixture 1`] = `
   >
     <InnerButton
       className="button teal submitting"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/toUrl.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/toUrl.test.js.snap
@@ -1,47 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Button /> rendered correctly with toRouterUrl fixture 1`] = `
+exports[`<Button /> rendered correctly with toNewWindowUrl fixture 1`] = `
 <Button
   color="teal"
   disabled={false}
-  done={false}
   icon=""
   keyline={false}
   link={false}
+  newWindow={true}
   onClick={[Function]}
   squared={false}
   submit={false}
-  submitting={false}
   to="#this-works!"
-  withRouter={true}
+  withRouter={false}
 >
   <div
     className="buttonContainer"
   >
     <InnerButton
       className="button teal"
+      newWindow={true}
       onClick={[Function]}
       submit={false}
       to="#this-works!"
-      withRouter={true}
+      withRouter={false}
     >
-      <Link
+      <a
         className="button teal"
-        replace={false}
-        to="#this-works!"
+        href="#this-works!"
+        target="_blank"
       >
-        <a
-          className="button teal"
-          href="#this-works!"
-          onClick={[Function]}
+        <div
+          className="content"
         >
-          <div
-            className="content"
-          >
-            I am a &lt;Link /&gt; tag
-          </div>
-        </a>
-      </Link>
+          I am an &lt;a  target="_blank" /&gt; tag
+        </div>
+      </a>
+    </InnerButton>
+  </div>
+</Button>
+`;
+
+exports[`<Button /> rendered correctly with toRouterUrl fixture 1`] = `
+<Button
+  color="teal"
+  disabled={false}
+  icon=""
+  keyline={false}
+  link={false}
+  newWindow={true}
+  onClick={[Function]}
+  squared={false}
+  submit={false}
+  to="#this-works!"
+  withRouter={false}
+>
+  <div
+    className="buttonContainer"
+  >
+    <InnerButton
+      className="button teal"
+      newWindow={true}
+      onClick={[Function]}
+      submit={false}
+      to="#this-works!"
+      withRouter={false}
+    >
+      <a
+        className="button teal"
+        href="#this-works!"
+        target="_blank"
+      >
+        <div
+          className="content"
+        >
+          I am an &lt;a  target="_blank" /&gt; tag
+        </div>
+      </a>
     </InnerButton>
   </div>
 </Button>
@@ -51,44 +86,38 @@ exports[`<Button /> rendered correctly with toUrl fixture 1`] = `
 <Button
   color="teal"
   disabled={false}
-  done={false}
   icon=""
   keyline={false}
   link={false}
+  newWindow={true}
   onClick={[Function]}
   squared={false}
   submit={false}
-  submitting={false}
   to="#this-works!"
-  withRouter={true}
+  withRouter={false}
 >
   <div
     className="buttonContainer"
   >
     <InnerButton
       className="button teal"
+      newWindow={true}
       onClick={[Function]}
       submit={false}
       to="#this-works!"
-      withRouter={true}
+      withRouter={false}
     >
-      <Link
+      <a
         className="button teal"
-        replace={false}
-        to="#this-works!"
+        href="#this-works!"
+        target="_blank"
       >
-        <a
-          className="button teal"
-          href="#this-works!"
-          onClick={[Function]}
+        <div
+          className="content"
         >
-          <div
-            className="content"
-          >
-            I am a &lt;Link /&gt; tag
-          </div>
-        </a>
-      </Link>
+          I am an &lt;a  target="_blank" /&gt; tag
+        </div>
+      </a>
     </InnerButton>
   </div>
 </Button>

--- a/src/components/Layout/Footer/tests/__snapshots__/withChild.test.js.snap
+++ b/src/components/Layout/Footer/tests/__snapshots__/withChild.test.js.snap
@@ -28,6 +28,7 @@ exports[`<Footer /> rendered correctly with withChild fixture 1`] = `
           icon="ArrowRight"
           keyline={false}
           link={false}
+          newWindow={false}
           onClick={[Function]}
           squared={false}
           submit={false}
@@ -38,6 +39,7 @@ exports[`<Footer /> rendered correctly with withChild fixture 1`] = `
           >
             <InnerButton
               className="button green"
+              newWindow={false}
               onClick={[Function]}
               submit={false}
               withRouter={false}

--- a/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/Children.test.js.snap
+++ b/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/Children.test.js.snap
@@ -2721,6 +2721,7 @@ exports[`<OnClickOutside(PrimaryNavigation) /> rendered correctly with Children 
             icon=""
             keyline={false}
             link={false}
+            newWindow={false}
             onClick={[Function]}
             squared={false}
             submit={false}
@@ -2731,6 +2732,7 @@ exports[`<OnClickOutside(PrimaryNavigation) /> rendered correctly with Children 
             >
               <InnerButton
                 className="button teal"
+                newWindow={false}
                 onClick={[Function]}
                 submit={false}
                 withRouter={false}

--- a/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/withTutorial.test.js.snap
+++ b/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/withTutorial.test.js.snap
@@ -514,6 +514,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                           id="takeTourBtn"
                           keyline={false}
                           link={false}
+                          newWindow={false}
                           onClick={[Function]}
                           squared={false}
                           submit={false}
@@ -524,6 +525,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                           >
                             <InnerButton
                               className="button teal"
+                              newWindow={false}
                               onClick={[Function]}
                               submit={false}
                               withRouter={false}
@@ -549,6 +551,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                           icon=""
                           keyline={false}
                           link={true}
+                          newWindow={false}
                           onClick={[Function]}
                           squared={false}
                           submit={false}
@@ -559,6 +562,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                           >
                             <InnerButton
                               className="button teal link"
+                              newWindow={false}
                               onClick={[Function]}
                               submit={false}
                               withRouter={false}
@@ -596,6 +600,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                               key="cb1"
                               keyline={false}
                               link={true}
+                              newWindow={false}
                               onClick={[Function]}
                               squared={false}
                               submit={false}
@@ -606,6 +611,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                               >
                                 <InnerButton
                                   className="button teal link rightElement"
+                                  newWindow={false}
                                   onClick={[Function]}
                                   submit={false}
                                   withRouter={false}
@@ -642,6 +648,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                               icon=""
                               keyline={false}
                               link={true}
+                              newWindow={false}
                               onClick={[Function]}
                               squared={false}
                               submit={false}
@@ -652,6 +659,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                               >
                                 <InnerButton
                                   className="button teal link rightElement"
+                                  newWindow={false}
                                   onClick={[Function]}
                                   submit={false}
                                   withRouter={false}

--- a/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/withTutorial.test.js.snap
+++ b/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/withTutorial.test.js.snap
@@ -307,14 +307,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
               <div
                 className="outer"
                 onClick={[Function]}
-                style={
-                  Object {
-                    "left": 76,
-                    "position": "absolute",
-                    "right": "auto",
-                    "top": 25,
-                  }
-                }
+                style={null}
               >
                 <FadeIn>
                   <div

--- a/src/components/PopUp/tests/__snapshots__/Default.test.js.snap
+++ b/src/components/PopUp/tests/__snapshots__/Default.test.js.snap
@@ -78,6 +78,7 @@ exports[`<PopUp /> rendered correctly with Default fixture 1`] = `
           icon=""
           keyline={false}
           link={false}
+          newWindow={false}
           onClick={[Function]}
           squared={false}
           submit={false}
@@ -88,6 +89,7 @@ exports[`<PopUp /> rendered correctly with Default fixture 1`] = `
           >
             <InnerButton
               className="button teal"
+              newWindow={false}
               onClick={[Function]}
               submit={false}
               withRouter={false}

--- a/src/components/Promotional/Banner/__snapshots__/Banner.test.js.snap
+++ b/src/components/Promotional/Banner/__snapshots__/Banner.test.js.snap
@@ -25,6 +25,7 @@ exports[`<Banner /> rendered correctly with a fixture 1`] = `
         keyline={false}
         large={true}
         link={false}
+        newWindow={false}
         onClick={[Function]}
         squared={false}
         submit={false}
@@ -35,6 +36,7 @@ exports[`<Banner /> rendered correctly with a fixture 1`] = `
         >
           <InnerButton
             className="button teal"
+            newWindow={false}
             onClick={[Function]}
             submit={false}
             withRouter={false}
@@ -60,6 +62,7 @@ exports[`<Banner /> rendered correctly with a fixture 1`] = `
         keyline={true}
         large={true}
         link={false}
+        newWindow={false}
         onClick={[Function]}
         squared={false}
         submit={false}
@@ -70,6 +73,7 @@ exports[`<Banner /> rendered correctly with a fixture 1`] = `
         >
           <InnerButton
             className="button white keyline"
+            newWindow={false}
             onClick={[Function]}
             submit={false}
             withRouter={false}

--- a/src/components/Promotional/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Promotional/Footer/__snapshots__/Footer.test.js.snap
@@ -25,6 +25,7 @@ exports[`<Footer /> rendered correctly with a fixture 1`] = `
         keyline={false}
         large={true}
         link={false}
+        newWindow={false}
         onClick={[Function]}
         squared={false}
         submit={false}
@@ -35,6 +36,7 @@ exports[`<Footer /> rendered correctly with a fixture 1`] = `
         >
           <InnerButton
             className="button teal"
+            newWindow={false}
             onClick={[Function]}
             submit={false}
             withRouter={false}
@@ -60,6 +62,7 @@ exports[`<Footer /> rendered correctly with a fixture 1`] = `
         keyline={true}
         large={true}
         link={false}
+        newWindow={false}
         onClick={[Function]}
         squared={false}
         submit={false}
@@ -70,6 +73,7 @@ exports[`<Footer /> rendered correctly with a fixture 1`] = `
         >
           <InnerButton
             className="button white keyline"
+            newWindow={false}
             onClick={[Function]}
             submit={false}
             withRouter={false}

--- a/src/components/Promotional/PromoDemo/__snapshots__/PromoDemo.test.js.snap
+++ b/src/components/Promotional/PromoDemo/__snapshots__/PromoDemo.test.js.snap
@@ -33,6 +33,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             keyline={false}
             large={true}
             link={false}
+            newWindow={false}
             onClick={[Function]}
             squared={false}
             submit={false}
@@ -43,6 +44,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             >
               <InnerButton
                 className="button teal"
+                newWindow={false}
                 onClick={[Function]}
                 submit={false}
                 withRouter={false}
@@ -68,6 +70,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             keyline={true}
             large={true}
             link={false}
+            newWindow={false}
             onClick={[Function]}
             squared={false}
             submit={false}
@@ -78,6 +81,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             >
               <InnerButton
                 className="button white keyline"
+                newWindow={false}
                 onClick={[Function]}
                 submit={false}
                 withRouter={false}
@@ -925,6 +929,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             keyline={false}
             large={true}
             link={false}
+            newWindow={false}
             onClick={[Function]}
             squared={false}
             submit={false}
@@ -935,6 +940,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             >
               <InnerButton
                 className="button teal"
+                newWindow={false}
                 onClick={[Function]}
                 submit={false}
                 withRouter={false}
@@ -960,6 +966,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             keyline={true}
             large={true}
             link={false}
+            newWindow={false}
             onClick={[Function]}
             squared={false}
             submit={false}
@@ -970,6 +977,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             >
               <InnerButton
                 className="button white keyline"
+                newWindow={false}
                 onClick={[Function]}
                 submit={false}
                 withRouter={false}

--- a/src/components/Tutorial/Tutorial.scss
+++ b/src/components/Tutorial/Tutorial.scss
@@ -124,10 +124,10 @@
   background: $grey_5;
 }
 
-
 .tutorialWrapper{
-  padding: 0 15px 0 15px;
+  padding: 15px;
 }
+
 .tutorialIndicator{
   float: right;
 }

--- a/src/components/Tutorial/Tutorial.scss
+++ b/src/components/Tutorial/Tutorial.scss
@@ -108,7 +108,7 @@
 .close {
   border-radius: 32px;
   cursor: pointer;
-  color: $he_black;
+  color: $grey_3;
   height: 24px;
   padding: 8px;
   position: absolute;

--- a/src/components/Tutorial/Tutorial.scss
+++ b/src/components/Tutorial/Tutorial.scss
@@ -4,14 +4,12 @@
   align-items: center;
   display: flex;
   justify-content: center;
-  pointer-events: none;
   position: fixed;
   left: 0;
   top: 0;
   z-index: 1000;
-  pointer-events: auto;
-  width: 50%;
-  height: 50%
+  width: 100%;
+  height: 100%
 }
 
 .fadeIn {
@@ -29,9 +27,7 @@
   font-family: $font-stack;
   top: 0;
   left: 150px;
-  max-height: 399px;
-  max-width: 544px;
-  min-width: 320px;
+  width: 390px;
   overflow-y: auto;
   position: absolute;
   text-align: center;
@@ -45,7 +41,9 @@
   &.popupCentered {
     position: absolute;
     top: 50%;
-    left: 50%
+    left: 50%;
+    margin-left: -195px;
+    margin-top: -195px;
   }
 }
 

--- a/src/components/Tutorial/TutorialStep.js
+++ b/src/components/Tutorial/TutorialStep.js
@@ -138,12 +138,12 @@ export default withTutorial(
             top: ownDomElement.getBoundingClientRect().height - 75,
           };
         }
-        const wrapperStyle = {
-          position: 'absolute',
-          top: newTop,
-          left,
-          right: 'auto',
-        };
+        const wrapperStyle = centered
+          ? null
+          : {
+              top: newTop,
+              left,
+            };
 
         return (
           <div

--- a/src/components/Tutorial/tests/__snapshots__/TutorialStep.test.js.snap
+++ b/src/components/Tutorial/tests/__snapshots__/TutorialStep.test.js.snap
@@ -3,8 +3,6 @@
 exports[`TutorialStep should follow its target element 1`] = `
 Object {
   "left": 200,
-  "position": "absolute",
-  "right": "auto",
   "top": 175,
 }
 `;


### PR DESCRIPTION
- Depends on #116

- Adds a `newWindow` prop to `Button`, which adds `target="_blank"` to the rendered link tag.

- Usage: `<Button to="/my/link" newWindow />`