### PR TITLE
Allow clicking the dots in the TutorialStep carousel

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,10 +108,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 85.83,
-        "statements": 85.83,
-        "functions": 75.61,
-        "branches": 82.16
+        "lines": 86.4,
+        "statements": 86.41,
+        "functions": 76.31,
+        "branches": 82.5
       }
     },
     "coverageReporters": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-fix": "eslint . --fix --env jest",
     "cosmos": "cosmos",
     "precommit": "yarn verify",
-    "verify": "yarn && yarn lint && yarn flow && yarn coverage && yarn jest-coverage-ratchet"
+    "verify": "yarn && yarn concurrently --kill-others-on-fail --names='lint,flow,test' 'yarn lint' 'yarn flow' 'yarn coverage' && yarn jest-coverage-ratchet"
   },
   "keywords": [
     "HealthEngine",
@@ -27,6 +27,7 @@
   "dependencies": {
     "babel-preset-flow": "^6.23.0",
     "classnames": "^2.2.5",
+    "concurrently": "^3.6.1",
     "coveralls": "^3.0.0",
     "enzyme": "^3.3.0",
     "enzyme-react-adapter-future": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "lines": 85.81,
         "statements": 85.81,
         "functions": 75.61,
-        "branches": 81.98
+        "branches": 82.07
       }
     },
     "coverageReporters": [

--- a/package.json
+++ b/package.json
@@ -107,10 +107,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 85.81,
-        "statements": 85.81,
+        "lines": 85.83,
+        "statements": 85.83,
         "functions": 75.61,
-        "branches": 82.07
+        "branches": 82.16
       }
     },
     "coverageReporters": [

--- a/src/components/Form/Button/Button.js
+++ b/src/components/Form/Button/Button.js
@@ -20,8 +20,17 @@ function InnerButton(props: {
   children: any,
   className: string,
   onClick: ?Function,
+  newWindow?: boolean,
 }) {
-  const { to, withRouter, submit, children, className, onClick } = props;
+  const {
+    to,
+    withRouter,
+    submit,
+    children,
+    className,
+    onClick,
+    newWindow,
+  } = props;
   if (!to) {
     return (
       <button
@@ -34,12 +43,14 @@ function InnerButton(props: {
     );
   }
 
+  const targetProp = newWindow ? { target: '_blank' } : {};
+
   return withRouter ? (
-    <Link to={to} className={className}>
+    <Link to={to} className={className} {...targetProp}>
       {children}
     </Link>
   ) : (
-    <a href={to} className={className}>
+    <a href={to} className={className} {...targetProp}>
       {children}
     </a>
   );
@@ -65,6 +76,7 @@ type Props = {
   className?: string,
   to?: string,
   withRouter: boolean,
+  newWindow: boolean,
 };
 
 class Button extends React.Component<Props> {
@@ -78,6 +90,7 @@ class Button extends React.Component<Props> {
     squared: false,
     onClick: () => null,
     withRouter: false,
+    newWindow: false,
   };
 
   handleClick = (event: SyntheticEvent<*>) => {
@@ -106,6 +119,7 @@ class Button extends React.Component<Props> {
       done,
       to,
       withRouter,
+      newWindow,
     } = this.props;
 
     const buttonClasses = classnames(
@@ -149,6 +163,7 @@ class Button extends React.Component<Props> {
           to={to}
           withRouter={withRouter}
           onClick={this.handleClick}
+          newWindow={newWindow}
         >
           {statusIcon || (
             <Fragment>

--- a/src/components/Form/Button/fixtures/toUrl.fixture.js
+++ b/src/components/Form/Button/fixtures/toUrl.fixture.js
@@ -22,4 +22,14 @@ export default [
     children: 'I am a <Link /> tag',
     simulateSubmission: true,
   },
+
+  {
+    name: 'toNewWindowUrl',
+    component: Button,
+    props: {
+      to: '#this-works!',
+      newWindow: true,
+    },
+    children: 'I am an <a  target="_blank" /> tag',
+  },
 ];

--- a/src/components/Form/Button/tests/__snapshots__/Blue.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Blue.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with blue fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with blue fixture 1`] = `
   >
     <InnerButton
       className="button blue"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Default.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Default.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with default fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with default fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Green.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Green.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with green fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with green fixture 1`] = `
   >
     <InnerButton
       className="button green"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Icon-legacy.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Icon-legacy.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with legacy icon fixture 1`] = `
   icon="Sync"
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with legacy icon fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Keyline.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Keyline.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   icon=""
   keyline={true}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   >
     <InnerButton
       className="button teal keyline"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Link.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Link.test.js.snap
@@ -7,6 +7,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   icon=""
   keyline={false}
   link={true}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -17,6 +18,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   >
     <InnerButton
       className="button teal link"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/Red.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/Red.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with red fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with red fixture 1`] = `
   >
     <InnerButton
       className="button red"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/White.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/White.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with white fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with white fixture 1`] = `
   >
     <InnerButton
       className="button white"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/disabled.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/disabled.test.js.snap
@@ -7,6 +7,7 @@ exports[`<Button /> rendered correctly with disabled fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -17,6 +18,7 @@ exports[`<Button /> rendered correctly with disabled fixture 1`] = `
   >
     <InnerButton
       className="button teal disabled"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/done.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/done.test.js.snap
@@ -13,6 +13,7 @@ exports[`<Button /> rendered correctly with done fixture 1`] = `
   }
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -23,6 +24,7 @@ exports[`<Button /> rendered correctly with done fixture 1`] = `
   >
     <InnerButton
       className="button done"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/iconLeft-Long-Title.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/iconLeft-Long-Title.test.js.snap
@@ -13,6 +13,7 @@ exports[`<Button /> rendered correctly with long-title fixture 1`] = `
   }
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -24,6 +25,7 @@ exports[`<Button /> rendered correctly with long-title fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/iconLeft.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/iconLeft.test.js.snap
@@ -13,6 +13,7 @@ exports[`<Button /> rendered correctly with iconLeft fixture 1`] = `
   }
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -24,6 +25,7 @@ exports[`<Button /> rendered correctly with iconLeft fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/iconRight.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/iconRight.test.js.snap
@@ -13,6 +13,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   }
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -24,6 +25,7 @@ exports[`<Button /> rendered correctly with fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/large.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/large.test.js.snap
@@ -9,6 +9,7 @@ exports[`<Button /> rendered correctly with large fixture 1`] = `
   keyline={false}
   large={true}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -20,6 +21,7 @@ exports[`<Button /> rendered correctly with large fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/small.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/small.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with small fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   small={true}
   squared={false}
@@ -20,6 +21,7 @@ exports[`<Button /> rendered correctly with small fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/squared.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/squared.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Button /> rendered correctly with squared fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={true}
   submit={false}
@@ -19,6 +20,7 @@ exports[`<Button /> rendered correctly with squared fixture 1`] = `
   >
     <InnerButton
       className="button teal squared"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/style.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/style.test.js.snap
@@ -7,6 +7,7 @@ exports[`<Button /> rendered correctly with style fixture 1`] = `
   icon=""
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   style={
@@ -33,6 +34,7 @@ exports[`<Button /> rendered correctly with style fixture 1`] = `
   >
     <InnerButton
       className="button teal"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/submitting.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/submitting.test.js.snap
@@ -12,6 +12,7 @@ exports[`<Button /> rendered correctly with submitting fixture 1`] = `
   }
   keyline={false}
   link={false}
+  newWindow={false}
   onClick={[Function]}
   squared={false}
   submit={false}
@@ -23,6 +24,7 @@ exports[`<Button /> rendered correctly with submitting fixture 1`] = `
   >
     <InnerButton
       className="button teal submitting"
+      newWindow={false}
       onClick={[Function]}
       submit={false}
       withRouter={false}

--- a/src/components/Form/Button/tests/__snapshots__/toUrl.test.js.snap
+++ b/src/components/Form/Button/tests/__snapshots__/toUrl.test.js.snap
@@ -1,47 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Button /> rendered correctly with toRouterUrl fixture 1`] = `
+exports[`<Button /> rendered correctly with toNewWindowUrl fixture 1`] = `
 <Button
   color="teal"
   disabled={false}
-  done={false}
   icon=""
   keyline={false}
   link={false}
+  newWindow={true}
   onClick={[Function]}
   squared={false}
   submit={false}
-  submitting={false}
   to="#this-works!"
-  withRouter={true}
+  withRouter={false}
 >
   <div
     className="buttonContainer"
   >
     <InnerButton
       className="button teal"
+      newWindow={true}
       onClick={[Function]}
       submit={false}
       to="#this-works!"
-      withRouter={true}
+      withRouter={false}
     >
-      <Link
+      <a
         className="button teal"
-        replace={false}
-        to="#this-works!"
+        href="#this-works!"
+        target="_blank"
       >
-        <a
-          className="button teal"
-          href="#this-works!"
-          onClick={[Function]}
+        <div
+          className="content"
         >
-          <div
-            className="content"
-          >
-            I am a &lt;Link /&gt; tag
-          </div>
-        </a>
-      </Link>
+          I am an &lt;a  target="_blank" /&gt; tag
+        </div>
+      </a>
+    </InnerButton>
+  </div>
+</Button>
+`;
+
+exports[`<Button /> rendered correctly with toRouterUrl fixture 1`] = `
+<Button
+  color="teal"
+  disabled={false}
+  icon=""
+  keyline={false}
+  link={false}
+  newWindow={true}
+  onClick={[Function]}
+  squared={false}
+  submit={false}
+  to="#this-works!"
+  withRouter={false}
+>
+  <div
+    className="buttonContainer"
+  >
+    <InnerButton
+      className="button teal"
+      newWindow={true}
+      onClick={[Function]}
+      submit={false}
+      to="#this-works!"
+      withRouter={false}
+    >
+      <a
+        className="button teal"
+        href="#this-works!"
+        target="_blank"
+      >
+        <div
+          className="content"
+        >
+          I am an &lt;a  target="_blank" /&gt; tag
+        </div>
+      </a>
     </InnerButton>
   </div>
 </Button>
@@ -51,44 +86,38 @@ exports[`<Button /> rendered correctly with toUrl fixture 1`] = `
 <Button
   color="teal"
   disabled={false}
-  done={false}
   icon=""
   keyline={false}
   link={false}
+  newWindow={true}
   onClick={[Function]}
   squared={false}
   submit={false}
-  submitting={false}
   to="#this-works!"
-  withRouter={true}
+  withRouter={false}
 >
   <div
     className="buttonContainer"
   >
     <InnerButton
       className="button teal"
+      newWindow={true}
       onClick={[Function]}
       submit={false}
       to="#this-works!"
-      withRouter={true}
+      withRouter={false}
     >
-      <Link
+      <a
         className="button teal"
-        replace={false}
-        to="#this-works!"
+        href="#this-works!"
+        target="_blank"
       >
-        <a
-          className="button teal"
-          href="#this-works!"
-          onClick={[Function]}
+        <div
+          className="content"
         >
-          <div
-            className="content"
-          >
-            I am a &lt;Link /&gt; tag
-          </div>
-        </a>
-      </Link>
+          I am an &lt;a  target="_blank" /&gt; tag
+        </div>
+      </a>
     </InnerButton>
   </div>
 </Button>

--- a/src/components/Form/DatePickers/DateRangePicker/DateRangePicker.test.js
+++ b/src/components/Form/DatePickers/DateRangePicker/DateRangePicker.test.js
@@ -9,3 +9,19 @@ fixtures.forEach(fixture => {
     fixture.name
   } fixture`, () => expect(context.getWrapper()).toMatchSnapshot());
 });
+
+describe('DateRangePicker', () => {
+  it('should open without errors', () => {
+    const fixture = fixtures.find(it => it.name === 'withChoices');
+    const context = createTestContext({ fixture });
+    context.mount();
+    const wrapper = context.getWrapper();
+
+    const instance = wrapper
+      .find('DateRangePicker')
+      .at(0)
+      .instance();
+
+    instance.handleSelectOpen();
+  });
+});

--- a/src/components/Layout/CarouselIndicator/CarouselIndicator.js
+++ b/src/components/Layout/CarouselIndicator/CarouselIndicator.js
@@ -12,23 +12,16 @@ import style from './CarouselIndicator.scss';
 type Props = {
   length: number,
   current: number,
-  showNext?: boolean,
   nextStep?: Function,
+  onDotClick?: Function,
   className?: string,
 };
 
 function CarouselIndicator(props: Props) {
-  const {
-    className,
-    length,
-    current,
-    showNext,
-    nextStep,
-    ...restProps
-  } = props;
+  const { className, length, current, nextStep, onDotClick } = props;
 
   return (
-    <div className={classnames(style.outer, className)} {...restProps}>
+    <div className={classnames(style.outer, className)}>
       <ol className={style.wrapper}>
         {Array(length)
           .fill(1)
@@ -38,6 +31,9 @@ function CarouselIndicator(props: Props) {
               className={classnames(style.item, {
                 [style.active]: current === index,
               })}
+              onClick={() => {
+                if (onDotClick) onDotClick(index);
+              }}
             />
           ))}
 

--- a/src/components/Layout/CarouselIndicator/tests/__snapshots__/Default.test.js.snap
+++ b/src/components/Layout/CarouselIndicator/tests/__snapshots__/Default.test.js.snap
@@ -15,18 +15,22 @@ exports[`<CarouselIndicator /> rendered correctly with Default fixture 1`] = `
       <li
         className="item"
         key="dot-1"
+        onClick={[Function]}
       />
       <li
         className="item active"
         key="dot-2"
+        onClick={[Function]}
       />
       <li
         className="item"
         key="dot-3"
+        onClick={[Function]}
       />
       <li
         className="item"
         key="dot-4"
+        onClick={[Function]}
       />
       <li
         className="nextBtn"

--- a/src/components/Layout/Footer/tests/__snapshots__/withChild.test.js.snap
+++ b/src/components/Layout/Footer/tests/__snapshots__/withChild.test.js.snap
@@ -28,6 +28,7 @@ exports[`<Footer /> rendered correctly with withChild fixture 1`] = `
           icon="ArrowRight"
           keyline={false}
           link={false}
+          newWindow={false}
           onClick={[Function]}
           squared={false}
           submit={false}
@@ -38,6 +39,7 @@ exports[`<Footer /> rendered correctly with withChild fixture 1`] = `
           >
             <InnerButton
               className="button green"
+              newWindow={false}
               onClick={[Function]}
               submit={false}
               withRouter={false}

--- a/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/Children.test.js.snap
+++ b/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/Children.test.js.snap
@@ -2721,6 +2721,7 @@ exports[`<OnClickOutside(PrimaryNavigation) /> rendered correctly with Children 
             icon=""
             keyline={false}
             link={false}
+            newWindow={false}
             onClick={[Function]}
             squared={false}
             submit={false}
@@ -2731,6 +2732,7 @@ exports[`<OnClickOutside(PrimaryNavigation) /> rendered correctly with Children 
             >
               <InnerButton
                 className="button teal"
+                newWindow={false}
                 onClick={[Function]}
                 submit={false}
                 withRouter={false}

--- a/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/withTutorial.test.js.snap
+++ b/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/withTutorial.test.js.snap
@@ -514,6 +514,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                           id="takeTourBtn"
                           keyline={false}
                           link={false}
+                          newWindow={false}
                           onClick={[Function]}
                           squared={false}
                           submit={false}
@@ -524,6 +525,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                           >
                             <InnerButton
                               className="button teal"
+                              newWindow={false}
                               onClick={[Function]}
                               submit={false}
                               withRouter={false}
@@ -549,6 +551,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                           icon=""
                           keyline={false}
                           link={true}
+                          newWindow={false}
                           onClick={[Function]}
                           squared={false}
                           submit={false}
@@ -559,6 +562,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                           >
                             <InnerButton
                               className="button teal link"
+                              newWindow={false}
                               onClick={[Function]}
                               submit={false}
                               withRouter={false}
@@ -596,6 +600,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                               key="cb1"
                               keyline={false}
                               link={true}
+                              newWindow={false}
                               onClick={[Function]}
                               squared={false}
                               submit={false}
@@ -606,6 +611,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                               >
                                 <InnerButton
                                   className="button teal link rightElement"
+                                  newWindow={false}
                                   onClick={[Function]}
                                   submit={false}
                                   withRouter={false}
@@ -642,6 +648,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                               icon=""
                               keyline={false}
                               link={true}
+                              newWindow={false}
                               onClick={[Function]}
                               squared={false}
                               submit={false}
@@ -652,6 +659,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                               >
                                 <InnerButton
                                   className="button teal link rightElement"
+                                  newWindow={false}
                                   onClick={[Function]}
                                   submit={false}
                                   withRouter={false}

--- a/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/withTutorial.test.js.snap
+++ b/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/withTutorial.test.js.snap
@@ -307,14 +307,7 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
               <div
                 className="outer"
                 onClick={[Function]}
-                style={
-                  Object {
-                    "left": 76,
-                    "position": "absolute",
-                    "right": "auto",
-                    "top": 25,
-                  }
-                }
+                style={null}
               >
                 <FadeIn>
                   <div

--- a/src/components/PopUp/tests/__snapshots__/Default.test.js.snap
+++ b/src/components/PopUp/tests/__snapshots__/Default.test.js.snap
@@ -78,6 +78,7 @@ exports[`<PopUp /> rendered correctly with Default fixture 1`] = `
           icon=""
           keyline={false}
           link={false}
+          newWindow={false}
           onClick={[Function]}
           squared={false}
           submit={false}
@@ -88,6 +89,7 @@ exports[`<PopUp /> rendered correctly with Default fixture 1`] = `
           >
             <InnerButton
               className="button teal"
+              newWindow={false}
               onClick={[Function]}
               submit={false}
               withRouter={false}

--- a/src/components/Promotional/Banner/__snapshots__/Banner.test.js.snap
+++ b/src/components/Promotional/Banner/__snapshots__/Banner.test.js.snap
@@ -25,6 +25,7 @@ exports[`<Banner /> rendered correctly with a fixture 1`] = `
         keyline={false}
         large={true}
         link={false}
+        newWindow={false}
         onClick={[Function]}
         squared={false}
         submit={false}
@@ -35,6 +36,7 @@ exports[`<Banner /> rendered correctly with a fixture 1`] = `
         >
           <InnerButton
             className="button teal"
+            newWindow={false}
             onClick={[Function]}
             submit={false}
             withRouter={false}
@@ -60,6 +62,7 @@ exports[`<Banner /> rendered correctly with a fixture 1`] = `
         keyline={true}
         large={true}
         link={false}
+        newWindow={false}
         onClick={[Function]}
         squared={false}
         submit={false}
@@ -70,6 +73,7 @@ exports[`<Banner /> rendered correctly with a fixture 1`] = `
         >
           <InnerButton
             className="button white keyline"
+            newWindow={false}
             onClick={[Function]}
             submit={false}
             withRouter={false}

--- a/src/components/Promotional/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Promotional/Footer/__snapshots__/Footer.test.js.snap
@@ -25,6 +25,7 @@ exports[`<Footer /> rendered correctly with a fixture 1`] = `
         keyline={false}
         large={true}
         link={false}
+        newWindow={false}
         onClick={[Function]}
         squared={false}
         submit={false}
@@ -35,6 +36,7 @@ exports[`<Footer /> rendered correctly with a fixture 1`] = `
         >
           <InnerButton
             className="button teal"
+            newWindow={false}
             onClick={[Function]}
             submit={false}
             withRouter={false}
@@ -60,6 +62,7 @@ exports[`<Footer /> rendered correctly with a fixture 1`] = `
         keyline={true}
         large={true}
         link={false}
+        newWindow={false}
         onClick={[Function]}
         squared={false}
         submit={false}
@@ -70,6 +73,7 @@ exports[`<Footer /> rendered correctly with a fixture 1`] = `
         >
           <InnerButton
             className="button white keyline"
+            newWindow={false}
             onClick={[Function]}
             submit={false}
             withRouter={false}

--- a/src/components/Promotional/PromoDemo/__snapshots__/PromoDemo.test.js.snap
+++ b/src/components/Promotional/PromoDemo/__snapshots__/PromoDemo.test.js.snap
@@ -33,6 +33,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             keyline={false}
             large={true}
             link={false}
+            newWindow={false}
             onClick={[Function]}
             squared={false}
             submit={false}
@@ -43,6 +44,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             >
               <InnerButton
                 className="button teal"
+                newWindow={false}
                 onClick={[Function]}
                 submit={false}
                 withRouter={false}
@@ -68,6 +70,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             keyline={true}
             large={true}
             link={false}
+            newWindow={false}
             onClick={[Function]}
             squared={false}
             submit={false}
@@ -78,6 +81,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             >
               <InnerButton
                 className="button white keyline"
+                newWindow={false}
                 onClick={[Function]}
                 submit={false}
                 withRouter={false}
@@ -925,6 +929,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             keyline={false}
             large={true}
             link={false}
+            newWindow={false}
             onClick={[Function]}
             squared={false}
             submit={false}
@@ -935,6 +940,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             >
               <InnerButton
                 className="button teal"
+                newWindow={false}
                 onClick={[Function]}
                 submit={false}
                 withRouter={false}
@@ -960,6 +966,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             keyline={true}
             large={true}
             link={false}
+            newWindow={false}
             onClick={[Function]}
             squared={false}
             submit={false}
@@ -970,6 +977,7 @@ exports[`<PromoDemo /> rendered correctly with a fixture 1`] = `
             >
               <InnerButton
                 className="button white keyline"
+                newWindow={false}
                 onClick={[Function]}
                 submit={false}
                 withRouter={false}

--- a/src/components/Tutorial/Tutorial.scss
+++ b/src/components/Tutorial/Tutorial.scss
@@ -124,10 +124,10 @@
   background: $grey_5;
 }
 
-
 .tutorialWrapper{
-  padding: 0 15px 0 15px;
+  padding: 15px;
 }
+
 .tutorialIndicator{
   float: right;
 }

--- a/src/components/Tutorial/Tutorial.scss
+++ b/src/components/Tutorial/Tutorial.scss
@@ -108,7 +108,7 @@
 .close {
   border-radius: 32px;
   cursor: pointer;
-  color: $he_black;
+  color: $grey_3;
   height: 24px;
   padding: 8px;
   position: absolute;

--- a/src/components/Tutorial/Tutorial.scss
+++ b/src/components/Tutorial/Tutorial.scss
@@ -4,14 +4,12 @@
   align-items: center;
   display: flex;
   justify-content: center;
-  pointer-events: none;
   position: fixed;
   left: 0;
   top: 0;
   z-index: 1000;
-  pointer-events: auto;
-  width: 50%;
-  height: 50%
+  width: 100%;
+  height: 100%
 }
 
 .fadeIn {
@@ -29,9 +27,7 @@
   font-family: $font-stack;
   top: 0;
   left: 150px;
-  max-height: 399px;
-  max-width: 544px;
-  min-width: 320px;
+  width: 390px;
   overflow-y: auto;
   position: absolute;
   text-align: center;
@@ -45,7 +41,9 @@
   &.popupCentered {
     position: absolute;
     top: 50%;
-    left: 50%
+    left: 50%;
+    margin-left: -195px;
+    margin-top: -195px;
   }
 }
 

--- a/src/components/Tutorial/TutorialCarousel.js
+++ b/src/components/Tutorial/TutorialCarousel.js
@@ -1,0 +1,25 @@
+// @flow
+import React from 'react';
+import CarouselIndicator from '../Layout/CarouselIndicator/CarouselIndicator';
+import withTutorial from './withTutorial';
+
+type Props = {
+  onTutorialJump: Function,
+  onTutorialAdvance: Function,
+  tutorialIndex: number,
+  tutorialSteps: string[],
+
+  className: string,
+};
+
+export default withTutorial((props: Props) => (
+  <CarouselIndicator
+    className={props.className}
+    length={props.tutorialSteps.length}
+    current={props.tutorialIndex}
+    nextStep={props.onTutorialAdvance}
+    onDotClick={index => {
+      props.onTutorialJump(props.tutorialSteps[index]);
+    }}
+  />
+));

--- a/src/components/Tutorial/TutorialStep.js
+++ b/src/components/Tutorial/TutorialStep.js
@@ -4,10 +4,10 @@ import classnames from 'classnames';
 import * as React from 'react';
 import onClickOutside from 'react-onclickoutside';
 import Icon from '../Icon';
-import CarouselIndicator from '../Layout/CarouselIndicator';
 import FadeIn from './FadeIn';
 import getCoordsForElementId from './getCoordsForElementId';
 import styles from './Tutorial.scss';
+import TutorialCarousel from './TutorialCarousel';
 import withTutorial from './withTutorial';
 
 function everyFrame(handler) {
@@ -35,7 +35,6 @@ type Props = {
   className?: ?string,
   centered?: boolean,
   tutorialSteps: string[],
-  onTutorialAdvance: Function,
   onTutorialDismiss: Function,
   tutorialIndex: number,
   attachTo?: string,
@@ -107,7 +106,6 @@ export default withTutorial(
 
       render() {
         const {
-          onTutorialAdvance,
           onTutorialDismiss,
           tutorialIndex,
           tutorialSteps,
@@ -167,12 +165,7 @@ export default withTutorial(
                   {children}
 
                   {showCarousel && (
-                    <CarouselIndicator
-                      className={styles.tutorialIndicator}
-                      length={tutorialSteps.length}
-                      current={tutorialIndex}
-                      nextStep={onTutorialAdvance}
-                    />
+                    <TutorialCarousel className={styles.tutorialIndicator} />
                   )}
                 </div>
               </div>

--- a/src/components/Tutorial/TutorialStep.js
+++ b/src/components/Tutorial/TutorialStep.js
@@ -138,12 +138,12 @@ export default withTutorial(
             top: ownDomElement.getBoundingClientRect().height - 75,
           };
         }
-        const wrapperStyle = {
-          position: 'absolute',
-          top: newTop,
-          left,
-          right: 'auto',
-        };
+        const wrapperStyle = centered
+          ? null
+          : {
+              top: newTop,
+              left,
+            };
 
         return (
           <div

--- a/src/components/Tutorial/tests/TutorialCarousel.test.js
+++ b/src/components/Tutorial/tests/TutorialCarousel.test.js
@@ -1,0 +1,59 @@
+// @flow
+import { mount } from 'enzyme';
+import React from 'react';
+import TutorialOwner from '../TutorialOwner';
+import TutorialSpy from './TutorialSpy';
+import TutorialCarousel from '../TutorialCarousel';
+
+function makeHarness(autoStart = false) {
+  return mount(
+    <TutorialOwner autoStart={autoStart} steps={['A', 'B', 'C', 'Z']}>
+      <TutorialSpy />
+      <TutorialCarousel />
+    </TutorialOwner>,
+  );
+}
+
+describe('TutorialCarousel', () => {
+  it('should allow jumping around', () => {
+    const harness = makeHarness(true);
+    const getDot = i =>
+      harness
+        // .find('TutorialCarousel')
+        .find('li.item')
+        .at(i);
+
+    expect(harness.find('#currentStep').text()).toBe('A');
+    expect(getDot(0).hasClass('active')).toBe(true);
+    expect(getDot(1).hasClass('active')).toBe(false);
+
+    harness.find('.nextBtn').simulate('click');
+
+    expect(getDot(0).hasClass('active')).toBe(false);
+    expect(getDot(1).hasClass('active')).toBe(true);
+
+    getDot(3).simulate('click');
+
+    expect(harness.find('#currentStep').text()).toBe('Z');
+
+    expect(getDot(0).hasClass('active')).toBe(false);
+    expect(getDot(3).hasClass('active')).toBe(true);
+
+    getDot(0).simulate('click');
+
+    expect(harness.find('#currentStep').text()).toBe('A');
+    expect(getDot(0).hasClass('active')).toBe(true);
+  });
+
+  it('should not render a Next button on the final step', () => {
+    const harness = makeHarness(true);
+    expect(harness.find('.nextBtn').length).toBe(1);
+    harness
+      // .find('TutorialCarousel')
+      .find('li.item')
+      .at(3)
+      .simulate('click');
+
+    expect(harness.find('.nextBtn').length).toBe(0);
+  });
+});

--- a/src/components/Tutorial/tests/__snapshots__/TutorialStep.test.js.snap
+++ b/src/components/Tutorial/tests/__snapshots__/TutorialStep.test.js.snap
@@ -3,8 +3,6 @@
 exports[`TutorialStep should follow its target element 1`] = `
 Object {
   "left": 200,
-  "position": "absolute",
-  "right": "auto",
   "top": 175,
 }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1812,6 +1812,14 @@ chalk@^2.1.0, chalk@^2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.2.0"
 
+chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
@@ -2034,6 +2042,10 @@ commander@2.12.x:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
+commander@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
+
 commander@^2.11.0, commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
@@ -2079,6 +2091,20 @@ concat-stream@^1.6.0:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+concurrently@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-3.6.1.tgz#2f95baec5c4051294dfbb55b57a3b98a3e2b45ec"
+  dependencies:
+    chalk "^2.4.1"
+    commander "2.6.0"
+    date-fns "^1.23.0"
+    lodash "^4.5.1"
+    read-pkg "^3.0.0"
+    rx "2.3.24"
+    spawn-command "^0.0.2-1"
+    supports-color "^3.2.3"
+    tree-kill "^1.1.0"
 
 concurrify@^1.0.0:
   version "1.0.3"
@@ -2379,6 +2405,10 @@ data-urls@^1.0.0:
     abab "^1.0.4"
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
+
+date-fns@^1.23.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -2776,6 +2806,12 @@ errno@^0.1.3:
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  dependencies:
+    is-arrayish "^0.2.1"
+
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
 
@@ -5153,6 +5189,10 @@ json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
 
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
@@ -5304,6 +5344,15 @@ load-json-file@^2.0.0:
     graceful-fs "^4.1.2"
     parse-json "^2.2.0"
     pify "^2.0.0"
+    strip-bom "^3.0.0"
+
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
     strip-bom "^3.0.0"
 
 load-script@^1.0.0:
@@ -5493,7 +5542,7 @@ lodash@^4.14.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.5:
+lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.5, lodash@^4.5.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -6361,6 +6410,13 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -6444,6 +6500,12 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  dependencies:
+    pify "^3.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.14"
@@ -7405,6 +7467,14 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
+
 readable-stream@1.0:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
@@ -7888,6 +7958,10 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
+rx@2.3.24:
+  version "2.3.24"
+  resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
+
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -8252,6 +8326,10 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
 sparkles@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.1.tgz#008db65edce6c50eec0c5e228e1945061dd0437c"
+
+spawn-command@^0.0.2-1:
+  version "0.0.2-1"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -8678,6 +8756,10 @@ tr46@^1.0.1:
 traverse@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+
+tree-kill@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.0.tgz#5846786237b4239014f05db156b643212d4c6f36"
 
 trim-newlines@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Depends on #117 
- When using a TutorialStep component, you can now click the 'position' dots at the bottom to jump back/forward through the steps
- PR also includes tests to bump coverage