### PR TITLE
Allow PrimaryNavigation to be controlled

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-fix": "eslint . --fix --env jest",
     "cosmos": "cosmos",
     "precommit": "yarn verify",
-    "verify": "yarn && yarn concurrently --kill-others-on-fail --names='lint,flow,test' 'yarn lint' 'yarn flow' 'yarn coverage' && yarn jest-coverage-ratchet"
+    "verify": "yarn && yarn lint && yarn flow && yarn coverage && yarn jest-coverage-ratchet"
   },
   "keywords": [
     "HealthEngine",
@@ -109,8 +109,8 @@
     "coverageThreshold": {
       "global": {
         "lines": 86.68,
-        "statements": 86.54,
-        "functions": 76.4,
+        "statements": 86.7,
+        "functions": 76.8,
         "branches": 82.67
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-fix": "eslint . --fix --env jest",
     "cosmos": "cosmos",
     "precommit": "yarn verify",
-    "verify": "yarn && yarn concurrently --kill-others-on-fail --names='lint,flow,test' 'yarn lint' 'yarn flow' 'yarn coverage' && yarn jest-coverage-ratchet"
+    "verify": "yarn && yarn lint && yarn flow && yarn coverage && yarn jest-coverage-ratchet"
   },
   "keywords": [
     "HealthEngine",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "he-react-ui",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "description": "Common UI elements for HealthEngine",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -108,10 +108,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 85.83,
-        "statements": 85.83,
-        "functions": 75.61,
-        "branches": 82.16
+        "lines": 86.4,
+        "statements": 86.41,
+        "functions": 76.31,
+        "branches": 82.5
       }
     },
     "coverageReporters": [

--- a/package.json
+++ b/package.json
@@ -108,9 +108,9 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 86.68,
-        "statements": 86.7,
-        "functions": 76.8,
+        "lines": 86.94,
+        "statements": 86.82,
+        "functions": 77.11,
         "branches": 82.67
       }
     },

--- a/package.json
+++ b/package.json
@@ -108,10 +108,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 86.4,
-        "statements": 86.41,
-        "functions": 76.31,
-        "branches": 82.5
+        "lines": 86.68,
+        "statements": 86.54,
+        "functions": 76.4,
+        "branches": 82.67
       }
     },
     "coverageReporters": [

--- a/src/components/Form/DatePickers/DateRangePicker/DateRangePicker.test.js
+++ b/src/components/Form/DatePickers/DateRangePicker/DateRangePicker.test.js
@@ -9,3 +9,19 @@ fixtures.forEach(fixture => {
     fixture.name
   } fixture`, () => expect(context.getWrapper()).toMatchSnapshot());
 });
+
+describe('DateRangePicker', () => {
+  it('should open without errors', () => {
+    const fixture = fixtures.find(it => it.name === 'withChoices');
+    const context = createTestContext({ fixture });
+    context.mount();
+    const wrapper = context.getWrapper();
+
+    const instance = wrapper
+      .find('DateRangePicker')
+      .at(0)
+      .instance();
+
+    instance.handleSelectOpen();
+  });
+});

--- a/src/components/Navigation/PrimaryNavigation/PrimaryNavigation.js
+++ b/src/components/Navigation/PrimaryNavigation/PrimaryNavigation.js
@@ -50,6 +50,7 @@ type Props = {
   logo: Logo,
   items: NavItem[],
   locations?: {}[], // TODO
+  onChangeOpenKey?: Function,
   onLocationChange?: Function,
   locationValue?: string,
   logoutRoute: string,
@@ -78,18 +79,26 @@ class PrimaryNavigation extends Component<Props, *> {
     return 'openKey' in this.props ? this.props.openKey : this.state.openKey;
   }
 
+  setOpenKey(openKey) {
+    if ('openKey' in this.props) {
+      if (this.props.onChangeOpenKey) this.props.onChangeOpenKey(openKey);
+    } else {
+      this.setState({ openKey });
+    }
+  }
+
   closeBucket = () => {
-    this.setState({ openKey: null });
+    this.setOpenKey(null);
   };
 
   toggleBucket = (key: string) => {
-    const { openKey } = this.state;
+    const openKey = this.getOpenKey();
 
-    this.setState({ openKey: key === openKey ? null : key });
+    this.setOpenKey(key === openKey ? null : key);
   };
 
   handleClickOutside = () => {
-    this.setState({ openKey: null });
+    this.setOpenKey(null);
   };
 
   renderSliders = () => {

--- a/src/components/Navigation/PrimaryNavigation/tests/controlled.test.js
+++ b/src/components/Navigation/PrimaryNavigation/tests/controlled.test.js
@@ -1,0 +1,28 @@
+// @flow
+import createTestContext from 'react-cosmos-test/enzyme';
+import defaultFixture from '../fixtures/Default.fixture';
+
+const onChangeOpenKey = jest.fn();
+
+const fixture = {
+  ...defaultFixture,
+  props: {
+    ...defaultFixture.props,
+    openKey: null,
+    onChangeOpenKey,
+  },
+};
+
+const { mount, getWrapper } = createTestContext({ fixture });
+
+beforeEach(mount);
+
+test('Primarynavigation calls its openKeyChange handlers', () => {
+  const wrapper = getWrapper();
+  const nav = wrapper.find('PrimaryNavigation');
+  expect(onChangeOpenKey).toHaveBeenCalledTimes(0);
+  nav.instance().toggleBucket('anything');
+  expect(onChangeOpenKey).toHaveBeenCalledWith('anything');
+  nav.instance().closeBucket();
+  expect(onChangeOpenKey).toHaveBeenCalledWith(null);
+});

--- a/src/components/PopUp/PopUp.js
+++ b/src/components/PopUp/PopUp.js
@@ -21,12 +21,14 @@ type Props = {
   style?: Object,
 };
 
+const noOp = () => null;
+
 class PopUp extends React.Component<Props, *> {
   static defaultProps = {
     modal: false,
     noPadding: false,
-    onClose: () => null,
-    onOpen: () => null,
+    onClose: noOp,
+    onOpen: noOp,
     showing: false,
   };
 

--- a/src/components/Tutorial/tests/TutorialStep.test.js
+++ b/src/components/Tutorial/tests/TutorialStep.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 import TutorialOwner from '../TutorialOwner';
 import TutorialStep from '../TutorialStep';
+import TutorialSpy from './TutorialSpy';
 
 jest.mock('../getCoordsForElementId.js');
 
@@ -16,6 +17,8 @@ function makeHarness(attachTo = null) {
       <TutorialStep id="Z" showCarousel>
         <span id="inStepZ" />
       </TutorialStep>
+
+      <TutorialSpy />
     </TutorialOwner>,
   );
 }
@@ -50,6 +53,24 @@ describe('TutorialStep', () => {
 
     expect(stepShown('A')).toBeFalsy();
     expect(stepShown('Z')).toBeFalsy();
+
+    harness.unmount();
+  });
+
+  it('Should dismiss on click outside', () => {
+    const harness = makeHarness();
+
+    const stepShown = id => harness.find(`#inStep${id}`).exists();
+
+    expect(stepShown('A')).toBeTruthy();
+
+    harness
+      .find('TutorialStep')
+      .first()
+      .instance()
+      .handleClickOutside();
+
+    expect(harness.find('#tutorialIndex').text()).toBe('-1');
 
     harness.unmount();
   });


### PR DESCRIPTION

* Depends on #118
* Adds an `onChangeOpenKey` prop to `PrimaryNavigation`, allowing the state of which bucket is open/closed to be fully controlled by its parent