### PR TITLE
Retain component names in compiled output to aid in debugging

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,5 +4,8 @@
     "es2015",
     "react",
     "stage-1"
+  ],
+  "plugins": [
+    "add-react-displayname"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,6 @@
     "stage-1"
   ],
   "plugins": [
-    "add-react-displayname"
+    "transform-react-display-name"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "author": "HealthEngine",
   "license": "MIT",
   "dependencies": {
+    "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-preset-flow": "^6.23.0",
     "classnames": "^2.2.5",
     "concurrently": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "he-react-ui",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "description": "Common UI elements for HealthEngine",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "HealthEngine",
   "license": "MIT",
   "dependencies": {
-    "babel-plugin-add-react-displayname": "^0.0.5",
+    "babel-plugin-transform-react-display-name": "^6.25.0",
     "babel-preset-flow": "^6.23.0",
     "classnames": "^2.2.5",
     "concurrently": "^3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,6 +803,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-add-react-displayname@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,10 +803,6 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-add-react-displayname@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
-
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
@@ -1171,7 +1167,7 @@ babel-plugin-transform-object-rest-spread@^6.22.0:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.26.0"
 
-babel-plugin-transform-react-display-name@^6.23.0:
+babel-plugin-transform-react-display-name@^6.23.0, babel-plugin-transform-react-display-name@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"
   dependencies:


### PR DESCRIPTION
- Adds a babel plugin to generate `displayName` properties for React classes, which allows them to show up in the dev tools with their real names, even after minification.
- no more `<t />` in debugging 👅 