### PR TITLE
Allow the logout button to be routed within react router

### DIFF
--- a/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/Children.test.js.snap
+++ b/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/Children.test.js.snap
@@ -2533,7 +2533,6 @@ exports[`<OnClickOutside(PrimaryNavigation) /> rendered correctly with Children 
                           ariaCurrent="true"
                           className="navLink"
                           key="logout"
-                          target="_self"
                           title="Logout"
                           to="/logout"
                         >
@@ -2544,7 +2543,6 @@ exports[`<OnClickOutside(PrimaryNavigation) /> rendered correctly with Children 
                               aria-current={false}
                               className="navLink"
                               replace={false}
-                              target="_self"
                               title="Logout"
                               to="/logout"
                             >
@@ -2553,7 +2551,6 @@ exports[`<OnClickOutside(PrimaryNavigation) /> rendered correctly with Children 
                                 className="navLink"
                                 href="/logout"
                                 onClick={[Function]}
-                                target="_self"
                                 title="Logout"
                               >
                                 <Logout

--- a/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/defaultState.test.js.snap
+++ b/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/defaultState.test.js.snap
@@ -2533,7 +2533,6 @@ exports[`<PrimaryNavigation /> rendered correctly with default fixture 1`] = `
                           ariaCurrent="true"
                           className="navLink"
                           key="logout"
-                          target="_self"
                           title="Logout"
                           to="/logout"
                         >
@@ -2544,7 +2543,6 @@ exports[`<PrimaryNavigation /> rendered correctly with default fixture 1`] = `
                               aria-current={false}
                               className="navLink"
                               replace={false}
-                              target="_self"
                               title="Logout"
                               to="/logout"
                             >
@@ -2553,7 +2551,6 @@ exports[`<PrimaryNavigation /> rendered correctly with default fixture 1`] = `
                                 className="navLink"
                                 href="/logout"
                                 onClick={[Function]}
-                                target="_self"
                                 title="Logout"
                               >
                                 <Logout

--- a/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/loading.test.js.snap
+++ b/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/loading.test.js.snap
@@ -292,7 +292,6 @@ exports[`<PrimaryNavigation /> rendered correctly with loading fixture 1`] = `
                       ariaCurrent="true"
                       className="navLink"
                       key="logout"
-                      target="_self"
                       title="Logout"
                       to="/logout"
                     >
@@ -303,7 +302,6 @@ exports[`<PrimaryNavigation /> rendered correctly with loading fixture 1`] = `
                           aria-current={false}
                           className="navLink"
                           replace={false}
-                          target="_self"
                           title="Logout"
                           to="/logout"
                         >
@@ -312,7 +310,6 @@ exports[`<PrimaryNavigation /> rendered correctly with loading fixture 1`] = `
                             className="navLink"
                             href="/logout"
                             onClick={[Function]}
-                            target="_self"
                             title="Logout"
                           >
                             <Logout

--- a/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/withTutorial.test.js.snap
+++ b/src/components/Navigation/PrimaryNavigation/tests/__snapshots__/withTutorial.test.js.snap
@@ -3871,7 +3871,6 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                                   ariaCurrent="true"
                                   className="navLink"
                                   key="logout"
-                                  target="_self"
                                   title="Logout"
                                   to="/logout"
                                 >
@@ -3882,7 +3881,6 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                                       aria-current={false}
                                       className="navLink"
                                       replace={false}
-                                      target="_self"
                                       title="Logout"
                                       to="/logout"
                                     >
@@ -3891,7 +3889,6 @@ exports[`<PrimaryNavigation /> rendered correctly with tutorial fixture 1`] = `
                                         className="navLink"
                                         href="/logout"
                                         onClick={[Function]}
-                                        target="_self"
                                         title="Logout"
                                       >
                                         <Logout

--- a/src/components/Navigation/SubNavigation/SubNavigation.js
+++ b/src/components/Navigation/SubNavigation/SubNavigation.js
@@ -141,7 +141,6 @@ class SubNavigation extends Component<Props> {
               to={logoutRoute}
               className={style.navLink}
               title="Logout"
-              target="_self"
             >
               <Logout className={style.icon} />Logout
             </NavLink>

--- a/src/components/Navigation/SubNavigation/tests/__snapshots__/SubNavigation.test.js.snap
+++ b/src/components/Navigation/SubNavigation/tests/__snapshots__/SubNavigation.test.js.snap
@@ -366,7 +366,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with OnePracticeWithCh
               ariaCurrent="true"
               className="navLink"
               key="logout"
-              target="_self"
               title="Logout"
               to="/logout"
             >
@@ -377,7 +376,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with OnePracticeWithCh
                   aria-current={false}
                   className="navLink"
                   replace={false}
-                  target="_self"
                   title="Logout"
                   to="/logout"
                 >
@@ -386,7 +384,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with OnePracticeWithCh
                     className="navLink"
                     href="/logout"
                     onClick={[Function]}
-                    target="_self"
                     title="Logout"
                   >
                     <Logout
@@ -858,7 +855,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with default fixture 1
               ariaCurrent="true"
               className="navLink"
               key="logout"
-              target="_self"
               title="Logout"
               to="/logout"
             >
@@ -869,7 +865,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with default fixture 1
                   aria-current={false}
                   className="navLink"
                   replace={false}
-                  target="_self"
                   title="Logout"
                   to="/logout"
                 >
@@ -878,7 +873,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with default fixture 1
                     className="navLink"
                     href="/logout"
                     onClick={[Function]}
-                    target="_self"
                     title="Logout"
                   >
                     <Logout
@@ -1350,7 +1344,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with loading fixture 1
               ariaCurrent="true"
               className="navLink"
               key="logout"
-              target="_self"
               title="Logout"
               to="/logout"
             >
@@ -1361,7 +1354,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with loading fixture 1
                   aria-current={false}
                   className="navLink"
                   replace={false}
-                  target="_self"
                   title="Logout"
                   to="/logout"
                 >
@@ -1370,7 +1362,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with loading fixture 1
                     className="navLink"
                     href="/logout"
                     onClick={[Function]}
-                    target="_self"
                     title="Logout"
                   >
                     <Logout
@@ -1842,7 +1833,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with multiPracticeNoCh
               ariaCurrent="true"
               className="navLink"
               key="logout"
-              target="_self"
               title="Logout"
               to="/logout"
             >
@@ -1853,7 +1843,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with multiPracticeNoCh
                   aria-current={false}
                   className="navLink"
                   replace={false}
-                  target="_self"
                   title="Logout"
                   to="/logout"
                 >
@@ -1862,7 +1851,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with multiPracticeNoCh
                     className="navLink"
                     href="/logout"
                     onClick={[Function]}
-                    target="_self"
                     title="Logout"
                   >
                     <Logout
@@ -2334,7 +2322,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with noChildren fixtur
               ariaCurrent="true"
               className="navLink"
               key="logout"
-              target="_self"
               title="Logout"
               to="/logout"
             >
@@ -2345,7 +2332,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with noChildren fixtur
                   aria-current={false}
                   className="navLink"
                   replace={false}
-                  target="_self"
                   title="Logout"
                   to="/logout"
                 >
@@ -2354,7 +2340,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with noChildren fixtur
                     className="navLink"
                     href="/logout"
                     onClick={[Function]}
-                    target="_self"
                     title="Logout"
                   >
                     <Logout
@@ -2826,7 +2811,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with noItem fixture 1`
               ariaCurrent="true"
               className="navLink"
               key="logout"
-              target="_self"
               title="Logout"
               to="/logout"
             >
@@ -2837,7 +2821,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with noItem fixture 1`
                   aria-current={false}
                   className="navLink"
                   replace={false}
-                  target="_self"
                   title="Logout"
                   to="/logout"
                 >
@@ -2846,7 +2829,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with noItem fixture 1`
                     className="navLink"
                     href="/logout"
                     onClick={[Function]}
-                    target="_self"
                     title="Logout"
                   >
                     <Logout
@@ -3318,7 +3300,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with onePractice fixtu
               ariaCurrent="true"
               className="navLink"
               key="logout"
-              target="_self"
               title="Logout"
               to="/logout"
             >
@@ -3329,7 +3310,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with onePractice fixtu
                   aria-current={false}
                   className="navLink"
                   replace={false}
-                  target="_self"
                   title="Logout"
                   to="/logout"
                 >
@@ -3338,7 +3318,6 @@ exports[`<withRouter(SubNavigation) /> rendered correctly with onePractice fixtu
                     className="navLink"
                     href="/logout"
                     onClick={[Function]}
-                    target="_self"
                     title="Logout"
                   >
                     <Logout


### PR DESCRIPTION
This removes the `target` attribute from the NavLink component for logout so that it can instead be routed within react router