### PR TITLE
Fix cosmos export for github pages

### DIFF
--- a/cosmos.config.js
+++ b/cosmos.config.js
@@ -7,4 +7,5 @@ module.exports = {
     'event-source-polyfill', // Hot reloads for IE11 and Edge
   ],
   port: 8989,
+  publicUrl: './',
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "he-react-ui",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "description": "Common UI elements for HealthEngine",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- Add relative path prefix to the cosmos export, so it can be served from a subdirectory